### PR TITLE
Add Saasify to the project showcase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [Haiti](https://orange-cyberdefense.github.io/haiti/#/) - A CLI tool to identify the hash type of a given hash.
 - [Rabid](https://orange-cyberdefense.github.io/rabid/#/) - A CLI tool and library allowing to simply decode all kind of BigIP cookies.
 - [🛸 Jasonelle](https://jasonelle.com) - Make iOS and Android Apps with JSON.
+- [Saasify](https://saasify.sh) - A new way for devs to earn passive income.
 
 
 ## Plugins


### PR DESCRIPTION
[Saasify](https://saasify.sh) also provides an example of [how](https://github.com/saasify-sh/saasify/blob/master/docs/index.html#L71) you can embed [Typeform](https://typeform.com) surveys on your docsify site.

Thanks!