### PR TITLE
Add `docsify-slides` to list of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [IT-films](https://greybax.github.com/awesome-IT-films) - A curated list of awesome movies, documentaries and TV series about hackers, geeks and IT in common, sorted by IMDB rating.
 - [zooming](http://desmonding.me/zooming/docs) - Image zoom that makes sense.
 - [vue-sticker](https://kamilocean.github.io/vue-sticker/#/) - Vue component, that helps to make sticky effects.
-- [Ts.LogDebug](https://typedproject.github.io/ts-log-debug/) - A multi channel logger written in TypeScript.
 - [vue-orgchart](https://spiritree.github.io/vue-orgchart) - Vue.js wrapper for OrgChart.js.
 - [Vue Content Loading](https://lucasleandro1204.github.io/vue-content-loading) - Easily build (or use presets) SVG loading cards like Facebook.
 - [Tracy Debugger for ProcessWire](https://adrianbj.github.io/TracyDebugger) - The ultimate debugging and development tool for the ProcessWire CMF/CMS.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-toc](https://github.com/mrpotatoes/docsify-toc) - Add a `Table of Contents` to your site. [@mrpotatoes](https://github.com/mrpotatoes).
 - [docsify-fontawesome](https://github.com/erickjx/docsify-fontawesome) - Add FontAwesome to documentation by tokens.
 - [docsify-footer-enh](https://github.com/erickjx/docsify-footer-enh) - Footer Enhancement plugin.
-
+- [docsify-slides](https://github.com/shawntabrizi/docsify-slides) - A plugin for creating slideshow-like pages.
 
 ## Themes
 


### PR DESCRIPTION
I have created a new docsify plugin which allows you to format docsify pages into a slideshow like format with a two column layout and some custom styling.

You can find the project here:
https://github.com/shawntabrizi/docsify-slides

And an example here:
https://www.shawntabrizi.com/docsify-slides/