### PR TITLE
fix: false positive dead url for status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 <div align="center">
 
+<!--lint ignore no-dead-urls-->
 # Awesome Docsify [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) ![Lint Awesome List](https://github.com/docsifyjs/awesome-docsify/workflows/Lint%20Awesome%20List/badge.svg)
 
 


### PR DESCRIPTION
Hopefully this fixes that issue. It seems many people run into it as they're planning on making it a WARN and not ERROR

This should only ignore for the next line