### PR TITLE
Add `docsify-valine` to list of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-changelog-plugin](https://github.com/anikethsaha/docsify-plugin/tree/master/packages/docsify-changelog-plugin) - Integrates your changelog in a sweet panel. 
 - [docsify-top-bannner-plugin](https://github.com/anikethsaha/docsify-plugin/tree/master/packages/docsify-top-banner-plugin) - Add a simple and sweet banner at the top in order to announce something.
 - [docsify-dark-mode](https://github.com/anikethsaha/docsify-plugin/tree/master/packages/docsify-dark-mode) - Add dark mode support in your docsify site.
+- [docsify-valine](https://github.com/daidi/docsify-valine/) -  A docsify plugin that allows you to use a fast, simple & powerful comment system [valine](https://github.com/xCss/Valine) on your [docsify](https://docsify.js.org/#/) pages.
 
 ## Themes
 


### PR DESCRIPTION
A fast, simple & powerful comment system for docsify . 

Append [valine](https://github.com/xCss/Valine) on your [docsify](https://docsify.js.org/#/) pages

You can find the project here:

https://github.com/daidi/docsify-valine/

And an example here:

https://daidi.github.io/docsify-valine/demo/#/