### PR TITLE
add word count for markdown files of docsify.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 
 ## Plugins
 
+- [docsify-count](https://github.com/827652549/docsify-count) - Add word count for markdown files of docsify.(添加字数统计)[@827652549](https://github.com/827652549).
 - [docsify-rtl](https://github.com/koliberr136a1/docsify-rtl) - Add rtl and bidi support to docsify [@koliberr136a1](https://github.com/koliberr136a1).
 - [docsify-remote-markdown](https://github.com/JerryC8080/docsify-remote-markdown) - Load markdown docs from remote. [@JerryC](https://github.com/JerryC8080).
 - [docsify-pagination](https://github.com/imyelo/docsify-pagination) - Pagination for docsify [@imyelo](https://github.com/imyelo).


### PR DESCRIPTION
This is a plugin to add word count for markdown files of docsify.
添加字数统计