### PR TITLE
Added showcase sample - How docsify based documentation site can be served using ASP.NET Core 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [:construction_worker: :orange_book: docsify-js-tutorial](https://github.com/MichaelCurrin/docsify-js-tutorial) - A guide to using DocsifyJS to setup and configure a docs site around your markdown docs. It is also built on DocsifyJS. [@MichaelCurrin](https://github.com/MichaelCurrin).
 - [:bird: :snake: python-twitter-guide](https://github.com/MichaelCurrin/python-twitter-guide) - Code snippets and links to docs around using the Twitter API and Tweepy on Python 3. [@MichaelCurrin](https://github.com/MichaelCurrin).
 - [:repeat_one: :hourglass_flowing_sand: :unicorn: unicron](https://github.com/MichaelCurrin/unicron) - A simple scheduler to ensure tasks run exactly once per day but get retried at intervals until the task passes. Ideal for machines which are not always online. [@MichaelCurrin](https://github.com/MichaelCurrin).
+- [docsify-dotnet-core](https://github.com/bharatdwarkani/docsify-dotnet-core) - This project demonstrates how we can add docisfy in a ASP.NET Core 3.0 application and serve documentation site.
 
 
 ## Plugins


### PR DESCRIPTION
Add a showcase sample. An example showcase project showcasing how docsify based documentation site can be served using ASP.NET Core 3.0

https://github.com/docsifyjs/awesome-docsify/issues/52