### PR TITLE
docs: codoxify to Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [:bird: :snake: python-twitter-guide](https://github.com/MichaelCurrin/python-twitter-guide) - Code snippets and links to docs around using the Twitter API and Tweepy on Python 3. [@MichaelCurrin](https://github.com/MichaelCurrin).
 - [:repeat_one: :hourglass_flowing_sand: :unicorn: unicron](https://github.com/MichaelCurrin/unicron) - A simple scheduler to ensure tasks run exactly once per day but get retried at intervals until the task passes. Ideal for machines which are not always online. [@MichaelCurrin](https://github.com/MichaelCurrin).
 - [docsify-dotnet-core](https://github.com/bharatdwarkani/docsify-dotnet-core) - This project demonstrates how we can add docisfy in a ASP.NET Core 3.0 application and serve documentation site.
+- [codoxify](https://github.com/wavejumper/codoxify) - Generate Clojure documentation for docsify.
 
 
 ## Plugins


### PR DESCRIPTION
[codoxify](https://github.com/wavejumper/codoxify) allows you to generate Clojure documentation for docsify