### PR TITLE
feat: add Restish to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [codoxify](https://github.com/wavejumper/codoxify) - Generate Clojure documentation for docsify.
 - [ebay-node-api](https://github.com/pajaydev/ebay-node-api) - Node.js wrapper for all eBay API's.
 - [Start Testing](https://dialex.github.io/start-testing) - A crowdsourced testing course, written by testers for testers wannabes.
+- [Restish](https://rest.sh/) - A CLI for modern REST APIs. Example of Docsify with custom syntax highlighting.
 
 ## Plugins
 


### PR DESCRIPTION
Docs are built using GitHub Pages. Uses docsify-themeable for styling and has custom lexers for syntax highlighting via PrismJS, as well as a custom syntax highlighting theme.