### PR TITLE
docs: add NoteBook to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [Restish](https://rest.sh/) - A CLI for modern REST APIs. Example of Docsify with custom syntax highlighting.
 - [Block Builder](https://blockbuilder.dev) - JS library for building Block Kit UIs for Slack apps.
 - [express-jsdoc-swagger](https://brikev.github.io/express-jsdoc-swagger-docs/#/) - Node.js library for generating Swagger OpenAPI 3.x UI.
+- [NoteBook](https://notebook.js.org) - Record the computer professional knowledge you have learned along the way.
 
 ## Plugins
 


### PR DESCRIPTION
Document website：https://notebook.js.org

Source code repository：https://github.com/wugenqiang/NoteBook

Description：Be an interesting and sharing person and record the computer professional knowledge you have learned along the way.

Thank you.