### PR TITLE
Adds `websequencediagrams` in the list of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-autoHeader](https://github.com/markbattistella/docsify-autoHeaders) - Turn your markdown into a cascading numbered document. Great for large documentation without manually numbering all the headings. [@markbattistella](https://github.com/markbattistella)
 - [docsify-sidebarFooter](https://github.com/markbattistella/docsify-sidebarFooter) - Add some links to the base of your sidebar - copyright year, company, Privacy Policy, Terms of Service.
 - [docsify-sidebar-collapse](https://github.com/iPeng6/docsify-sidebar-collapse) - Support docsify sidebar catalog expand and collapse.
-- [websequencediagrams-docsify](https://github.com/aajiwani/websequencediagrams-docsify) - A plugin to embed (WebSequenceDiagrams)[https://www.websequencediagrams.com/] right into your documentation.
+- [websequencediagrams-docsify](https://github.com/aajiwani/websequencediagrams-docsify) - A plugin to embed [WebSequenceDiagrams](https://www.websequencediagrams.com) right into your documentation.
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-autoHeader](https://github.com/markbattistella/docsify-autoHeaders) - Turn your markdown into a cascading numbered document. Great for large documentation without manually numbering all the headings. [@markbattistella](https://github.com/markbattistella)
 - [docsify-sidebarFooter](https://github.com/markbattistella/docsify-sidebarFooter) - Add some links to the base of your sidebar - copyright year, company, Privacy Policy, Terms of Service.
 - [docsify-sidebar-collapse](https://github.com/iPeng6/docsify-sidebar-collapse) - Support docsify sidebar catalog expand and collapse.
+- [websequencediagrams-docsify](https://github.com/aajiwani/websequencediagrams-docsify) - A plugin to embed (WebSequenceDiagrams)[https://www.websequencediagrams.com/] right into your documentation.
 
 ## Themes
 


### PR DESCRIPTION
Web Sequence Diagrams are an easy way for developers to express a flow for their matters of work, I felt it was missing from docsify; Hence the PR :-)