### PR TITLE
add plugin - docsify-plugin-title

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-kroki](https://github.com/zuisong/docsify-kroki) - A plugin to integration [kroki](https://kroki.io/) into docsify. [@zuisong](https://github.com/zuisong).
 - [docsify-charty](https://github.com/markbattistella/docsify-charty) - Add some charts and graphs to your docsify website. Pie charts, doughnut charts, sectional, bar and column graphs, line and plot graphs, and a review block. Everything you need if you need to visualise some numbers!
 - [docsify-accordify](https://github.com/atleastzero/docsify-accordify) - Easily use accordions in your docsify site. [@atleastzero](https://github.com/atleastzero).
+- [docsify-plugin-title](https://github.com/Sujaykumarh/docsify-plugin-title) - Customize docisify page title. [@sujaykumarh](https://github.com/sujaykumarh)
 
 ## Themes
 


### PR DESCRIPTION
Plugin [docsify-plugin-title](https://github.com/Sujaykumarh/docsify-plugin-title) helps to add additional text to docsify generated page title 

consider **default page title** generated by docsify

    Getting Started

**use cases** adding suffix or prefix to title

- add prefix

     Docsify | Getting Started

-  add suffix

     Getting Started | v1.0.1

- add suffix & prefix

     Docsify | Getting Started | v1.0.1

<br>

can customize the separator [default is | character]

for more info please checkout the [readme](https://github.com/Sujaykumarh/docsify-plugin-title#readme)
