### PR TITLE
add docsify-plugin-footer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-dotnet-core](https://github.com/bharatdwarkani/docsify-dotnet-core) - This project demonstrates how we can add docisfy in a ASP.NET Core 3.0 application and serve documentation site.
 - [:construction_worker: :orange_book: docsify-js-tutorial](https://michaelcurrin.github.io/docsify-js-tutorial) - A guide to using DocsifyJS to setup and configure a docs site around your markdown docs. It is also built on DocsifyJS. @MichaelCurrin.
 - [docsify-notebooks](https://github.com/MonkeyAndres/docsify-notebooks) - Template for building notebooks with DocsifyJS. Made with ❤️ by @MonkeyAndres.
-- :whale: [docsify-docker](https://github.com/Sujaykumarh/docsify-docker) - :whale2: Docisify Docker image. [@sujaykumarh](https://github.com/sujaykumarh)
+- :whale: [docsify-docker](https://github.com/Sujaykumarh/docsify-docker) - :whale2: Docisify Docker image. @sujaykumarh
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-accordify](https://github.com/atleastzero/docsify-accordify) - Easily use accordions in your docsify site. [@atleastzero](https://github.com/atleastzero).
 - [docsify-plugin-title](https://github.com/Sujaykumarh/docsify-plugin-title) - Customize docisify page title. [@sujaykumarh](https://github.com/sujaykumarh)
 - [docsify-drawio](https://github.com/KonghaYao/docsify-drawio) - This is a docsify plugin that can convert drawio xml Data to a picture in your docs. [@KonghaYao](https://github.com/KonghaYao)
+- [docsify-plugin-footer](https://github.com/Sujaykumarh/docsify-plugin-footer) - simplified docisify page footer. @sujaykumarh
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-accordify](https://github.com/atleastzero/docsify-accordify) - Easily use accordions in your docsify site. [@atleastzero](https://github.com/atleastzero).
 - [docsify-plugin-title](https://github.com/Sujaykumarh/docsify-plugin-title) - Customize docisify page title. [@sujaykumarh](https://github.com/sujaykumarh)
 - [docsify-drawio](https://github.com/KonghaYao/docsify-drawio) - This is a docsify plugin that can convert drawio xml Data to a picture in your docs. [@KonghaYao](https://github.com/KonghaYao)
-- [docsify-plugin-footer](https://github.com/Sujaykumarh/docsify-plugin-footer) - simplified docisify page footer. @sujaykumarh
+- [docsify-plugin-footer](https://github.com/Sujaykumarh/docsify-plugin-footer) - simplified docisify page footer. @sujaykumarh.
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-dotnet-core](https://github.com/bharatdwarkani/docsify-dotnet-core) - This project demonstrates how we can add docisfy in a ASP.NET Core 3.0 application and serve documentation site.
 - [:construction_worker: :orange_book: docsify-js-tutorial](https://michaelcurrin.github.io/docsify-js-tutorial) - A guide to using DocsifyJS to setup and configure a docs site around your markdown docs. It is also built on DocsifyJS. @MichaelCurrin.
 - [docsify-notebooks](https://github.com/MonkeyAndres/docsify-notebooks) - Template for building notebooks with DocsifyJS. Made with ❤️ by @MonkeyAndres.
+- :whale: [docsify-docker](https://github.com/Sujaykumarh/docsify-docker) - :whale2: Docisify Docker image. [@sujaykumarh](https://github.com/sujaykumarh)
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ A curated list of awesome things related to <a href="//docsify.js.org">docsify</
 - [docsify-accordify](https://github.com/atleastzero/docsify-accordify) - Easily use accordions in your docsify site. [@atleastzero](https://github.com/atleastzero).
 - [docsify-plugin-title](https://github.com/Sujaykumarh/docsify-plugin-title) - Customize docisify page title. [@sujaykumarh](https://github.com/sujaykumarh)
 - [docsify-drawio](https://github.com/KonghaYao/docsify-drawio) - This is a docsify plugin that can convert drawio xml Data to a picture in your docs. [@KonghaYao](https://github.com/KonghaYao)
-- [docsify-plugin-footer](https://github.com/Sujaykumarh/docsify-plugin-footer) - simplified docisify page footer. @sujaykumarh.
+- [docsify-plugin-footer](https://github.com/Sujaykumarh/docsify-plugin-footer) - Simplified docisify page footer. @sujaykumarh.
 
 ## Themes
 


### PR DESCRIPTION
There are already footer plugins in awesome-docsify namely 

- docsify-footer-enh
- docsify-sidebarFooter
- docsify-footer

but those serve different purpose not what i was looking for, i needed something simple to configure, easy to customize and theme if needed by css

my [plugin](https://github.com/sujaykumarh/docsify-plugin-footer) adds footer as follows and can be seen in [repo readme](https://github.com/sujaykumarh/docsify-plugin-footer) too with available [config options](https://github.com/sujaykumarh/docsify-plugin-footer#-configuration)

```
        |      content here
        |      ....
sidebar |      ....
        |
        |
        |      ___________________________________________________________________
        |
        |      copyright (c) 2021 copyrightOwner.              Powered by docsify.
        |      [---copyrightExtra---]

```

**Links**

[plugin repo](https://github.com/sujaykumarh/docsify-plugin-footer)

for usage and example visit

- [my-notebook](https://notebook.sujaykumarh.com/)
- [nginxwall docs](https://docs.nginxwall.com/)
