### PR TITLE
Replace sunsetted docsify-glossary project by bugfix fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [docsify-commento](https://github.com/ndom91/docsify-commento) - Append [commento](https://gitlab.com/commento/commento) section to the bottom of every page [@ndom91](https://github.com/ndom91).
 - [docsify-gifcontrol](https://gbodigital.github.io/docsify-gifcontrol) - A docsify plugin that adds customizable player controls to GIFs. [@adambergman](https://github.com/adambergman) from [@gbodigital](https://github.com/gbodigital).
 - [docsify-example-panels](https://github.com/VagnerDomingues/docsify-example-panels) - A plugin for rendering slate alike right example panels.
-- [docsify-glossary](https://github.com/TheGreenToaster/docsify-glossary) - A plugin to create a simple glossary for common terms.
+- [docsify-glossary](https://github.com/stijn-dejongh/docsify-glossary) -  A plugin to create a simple glossary for common terms. Revision of [the original glossary plugin](https://github.com/TheGreenToaster/docsify-glossary) containing bugfixes and additional configuration options. [@stijn-dejongh](https://github.com/stijn-dejongh).
 - [docsify-toc](https://github.com/mrpotatoes/docsify-toc) - Add a `Table of Contents` to your site. [@mrpotatoes](https://github.com/mrpotatoes).
 - [docsify-fontawesome](https://github.com/erickjx/docsify-fontawesome) - Add FontAwesome to documentation by tokens.
 - [docsify-footer-enh](https://github.com/erickjx/docsify-footer-enh) - Footer Enhancement plugin.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [docsify-commento](https://github.com/ndom91/docsify-commento) - Append [commento](https://gitlab.com/commento/commento) section to the bottom of every page [@ndom91](https://github.com/ndom91).
 - [docsify-gifcontrol](https://gbodigital.github.io/docsify-gifcontrol) - A docsify plugin that adds customizable player controls to GIFs. [@adambergman](https://github.com/adambergman) from [@gbodigital](https://github.com/gbodigital).
 - [docsify-example-panels](https://github.com/VagnerDomingues/docsify-example-panels) - A plugin for rendering slate alike right example panels.
-- [docsify-glossary](https://github.com/stijn-dejongh/docsify-glossary) -  A plugin to create a simple glossary for common terms. Revision of [the original glossary plugin](https://github.com/TheGreenToaster/docsify-glossary) containing bugfixes and additional configuration options. [@stijn-dejongh](https://github.com/stijn-dejongh).
+- [docsify-glossary](https://github.com/stijn-dejongh/docsify-glossary) - A plugin to create a simple glossary for common terms. Revision of [the original glossary plugin](https://github.com/TheGreenToaster/docsify-glossary) containing bugfixes and additional configuration options. [@stijn-dejongh](https://github.com/stijn-dejongh).
 - [docsify-toc](https://github.com/mrpotatoes/docsify-toc) - Add a `Table of Contents` to your site. [@mrpotatoes](https://github.com/mrpotatoes).
 - [docsify-fontawesome](https://github.com/erickjx/docsify-fontawesome) - Add FontAwesome to documentation by tokens.
 - [docsify-footer-enh](https://github.com/erickjx/docsify-footer-enh) - Footer Enhancement plugin.


### PR DESCRIPTION
The original plugins author, @TheGreenToaster has not been active for multiple years.
As many open issues and feature requests existed, I provided a forked version with bugfixes and feature enhancements.
It does not look like the original author is set to return any time soon, so I propose to replace/append this list pointing to my fork (which references the original project).

Following the Contributing guide on this project, here is an overview of improvements I have applied on top of the original project:
- glossary location can now be configured
- structure of glossary file (depth of terminology headers) can be configured
- terminology in titles is now dealt with appropriatly (no more missing spaces + added option to disable in-title word replacement)
- word replacement can now handle multi-word phrases
- code blocks are ignored during word-replacement
- demo page through [github-pages](https://stijn-dejongh.github.io/docsify-glossary/#/) deployment
- dependency upgrades to address CVEs as indicated by dependabot