### PR TITLE
Re-added robot emoji to chatgpt.js to pass lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [八尺妖剑的文档库](https://docs.waer.ltd/#/) - A personal project documentation repository.
 - [做字体网](http://www.zuoziti.com/) - A website that teaches people to make Chinese handwriting fonts. (如何制作有版权的手写字体并出售?)
 - [Condorcet.io](https://www.condorcet.io) - Documentation for the [Condorcet PHP](https://github.com/julien-boudry/Condorcet) project.
-- [chatgpt.js](https://chatgpt.js.org) - A powerful client-side JavaScript library for ChatGPT.
+- [🤖 chatgpt.js](https://chatgpt.js.org) - A powerful client-side JavaScript library for ChatGPT.
 
 ## Community Resources
 


### PR DESCRIPTION
In https://github.com/docsifyjs/awesome-docsify/pull/256#issuecomment-1516284958 @Koooooo-7 revealed lint fails when emoji is before/after `-` so I moved it to title