### PR TITLE
docs: add docsify-gitalk-with-footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [docsify-mango-valine](https://github.com/mg0324/docsify-mango-valine) - A docsify plugin for support valine comments, expose config item.
 - [docsify-terminal-block](https://github.com/dolanmiu/docsify-terminal-block) - A docsify plugin to add pretty terminal code blocks 🖥️ to your docs. It has `Copy to Clipboard` functionality too.
 - [docsify-docx-converter](https://github.com/simonguo/docsify-docx-converter) - A tool for building docx based on your docsify project. [@simonguo](https://github.com/simonguo)
+- [docsify-gitalk-with-footer](https://github.com/pikapikapikaori/docsify-gitalk-with-footer) - A plugin that fixs gitalk comment problem while using docsify hash mode. It can also add a footer under gitalk container. [@pikapikapikaori](https://github.com/pikapikapikaori)
 
 ## Themes
 


### PR DESCRIPTION
Hi there, I recently developed a small plugin to enhance Gitalk for docsify: **docsify-gitalk-with-footer**. It fixes following problems: 

- While using hash mode in docsify, Gitalk comments won't display correctly after switching to another article.
- Adds a footer under Gitalk container so that the style of Gitalk won't look strange.

Please kindly remind me further modification that I should do before merging this pr, thanks! 