### PR TITLE
add a power Tree webcompoent use in docsify

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - :hatching_chick:[docsify-Preview](https://marketplace.visualstudio.com/items?itemName=dzylikecode.docsify-preview):penguin: - A VSCode extension for previewing docsify markdown files in VSCode. Supports auto-refresh, sync scroll, open the Markdown from the preview, open the preview in the default browser.:mushroom:
 - [create-docsify-plugin](https://github.com/corentinleberre/create-docsify-plugin) - A ready-to-use template to create your own Docsify plugin from scratch.
 - [try-docsify](https://github.com/alertbox/devcontainers-try-docsify) - A ready to go [docsify-template](https://github.com/docsifyjs/docsify-template) repo powered by [Dev Containers](https://containers.dev) that requires no build steps.
+- [LiteTree WebComponent](https://zhangfisher.github.io/lite-tree/integration/docsify.html) - A power Tree webcompoent use in docsify
 
 ## Plugins
 


### PR DESCRIPTION
A power Tree webcompoent use in docsify.

`LiteTree` is a tree webcompoent use in docsify