### PR TITLE
Add a breadcrumb plugin link to the plugin section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [docsify-vite-coverpage](https://github.com/LIGMATV/docsify-vite-coverpage) - A new responsive vite-like coverpage for your docs.
 - [docsify-dark-switcher](https://github.com/LIGMATV/docsify-dark-switcher) - Easily switch toggle to light and dark theme for your Docsify, customizable and works in any CSS themes.
 - [docsify-auth](https://github.com/mg0324/docsify-auth) - A docsify plugin for support page auth with config.
+- [docsify-breadcrumb](https://github.com/FranCarstens/docsify-breadcrumb) - Add a customizable breadcrumb to the top of each page.
 
 ## Themes
 


### PR DESCRIPTION
I've created a breadcrumb plugin and would like to add it to the available plugins.

https://github.com/FranCarstens/docsify-breadcrumb