### PR TITLE
add(plugin): docsify-docsify-fontsize to resize fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [docsify-dark-switcher](https://github.com/LIGMATV/docsify-dark-switcher) - Easily switch toggle to light and dark theme for your Docsify, customizable and works in any CSS themes.
 - [docsify-auth](https://github.com/mg0324/docsify-auth) - A docsify plugin for support page auth with config.
 - [docsify-breadcrumb](https://github.com/FranCarstens/docsify-breadcrumb) - Add a customizable breadcrumb to the top of each page.
+- [docsify-docsify-fontsize](https://github.com/SDU-Little-River/docsify-fontsize) - A docsify plugin allow users to customize the font size.
 
 ## Themes
 


### PR DESCRIPTION
A docsify plugin allow users to customize the font size
[example](https://github.com/docsifyjs/awesome-docsify/pull/301)