### PR TITLE
Add docsify-sitemap – sitemap generator for Docsify via web, CLI, or GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - :hatching_chick:[docsify-Preview](https://marketplace.visualstudio.com/items?itemName=dzylikecode.docsify-preview):penguin: - A VSCode extension for previewing docsify markdown files in VSCode. Supports auto-refresh, sync scroll, open the Markdown from the preview, open the preview in the default browser.:mushroom:
 - [create-docsify-plugin](https://github.com/corentinleberre/create-docsify-plugin) - A ready-to-use template to create your own Docsify plugin from scratch.
 - [try-docsify](https://github.com/alertbox/devcontainers-try-docsify) - A ready to go [docsify-template](https://github.com/docsifyjs/docsify-template) repo powered by [Dev Containers](https://containers.dev) that requires no build steps.
-- [docsify-sitemap](https://github.com/tenelabs/docsify-sitemap) – Instantly generate structured sitemaps for your Docsify projects. Use it via the [web app](https://tenelabs.github.io/docsify-sitemap/), the CLI, or automate it with [GitHub Actions](https://github.com/tenelabs/docsify-sitemap#automated-github-action).
+- [docsify-sitemap](https://github.com/tenelabs/docsify-sitemap) - Instantly generate structured sitemaps for your Docsify projects. Use it via the [web app](https://tenelabs.github.io/docsify-sitemap/), the CLI, or with an [automated workflow](https://github.com/tenelabs/docsify-sitemap#automated-github-action).
+
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - :hatching_chick:[docsify-Preview](https://marketplace.visualstudio.com/items?itemName=dzylikecode.docsify-preview):penguin: - A VSCode extension for previewing docsify markdown files in VSCode. Supports auto-refresh, sync scroll, open the Markdown from the preview, open the preview in the default browser.:mushroom:
 - [create-docsify-plugin](https://github.com/corentinleberre/create-docsify-plugin) - A ready-to-use template to create your own Docsify plugin from scratch.
 - [try-docsify](https://github.com/alertbox/devcontainers-try-docsify) - A ready to go [docsify-template](https://github.com/docsifyjs/docsify-template) repo powered by [Dev Containers](https://containers.dev) that requires no build steps.
+- [docsify-sitemap](https://github.com/tenelabs/docsify-sitemap) – Instantly generate structured sitemaps for your Docsify projects. Use it via the [web app](https://tenelabs.github.io/docsify-sitemap/), the CLI, or automate it with [GitHub Actions](https://github.com/tenelabs/docsify-sitemap#automated-github-action).
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - :hatching_chick:[docsify-Preview](https://marketplace.visualstudio.com/items?itemName=dzylikecode.docsify-preview):penguin: - A VSCode extension for previewing docsify markdown files in VSCode. Supports auto-refresh, sync scroll, open the Markdown from the preview, open the preview in the default browser.:mushroom:
 - [create-docsify-plugin](https://github.com/corentinleberre/create-docsify-plugin) - A ready-to-use template to create your own Docsify plugin from scratch.
 - [try-docsify](https://github.com/alertbox/devcontainers-try-docsify) - A ready to go [docsify-template](https://github.com/docsifyjs/docsify-template) repo powered by [Dev Containers](https://containers.dev) that requires no build steps.
-- [docsify-sitemap](https://github.com/tenelabs/docsify-sitemap) - Instantly generate structured sitemaps for your Docsify projects. Use it via the [web app](https://tenelabs.github.io/docsify-sitemap/), the CLI, or with an [automated workflow](https://github.com/tenelabs/docsify-sitemap#automated-github-action).
+- [docsify-sitemap](https://github.com/tenelabs/docsify-sitemap) - Instantly generate structured sitemaps for your Docsify projects. Use it via the [web app](https://tenelabs.github.io/docsify-sitemap/), the CLI, or automate it with GitHub Actions.
 
 
 ## Plugins


### PR DESCRIPTION

## Features

- **GitHub Repo Crawler**: Automatically fetches all `.md` files from any public GitHub repository.
- **Local Mode**: Generate sitemap directly from local markdown files — no GitHub needed.
- **Standards-compliant `sitemap.xml`**: Fully valid and optimized for search engines.
- **Interactive CLI**: Prompt-driven interface makes setup simple and quick.
- **GitHub PAT Support**: Use Personal Access Tokens to avoid rate limits.
- **Branch & Base Support**: Target specific branches and directories for sitemap generation.
- **Configurable Output Path**: Customize where your sitemap is written (default: `.public/sitemap.xml`).
- **GitHub Workflow Integration**: Seamless CI/CD automation with ready-to-use GitHub Actions.
- **Web UI (Demo)**: Try it instantly online no installation required: [Live Demo](https://tenelabs.github.io/docsify-sitemap)


## Usage

```bash
npx docsify-sitemap
```

Or run it fully configured:

```bash
npx docsify-sitemap --url https://username.github.io/repo --owner username --repo repo --branch main --pat YOUR_PAT --output ./sitemap.xml
```

## Try It Now

- **Live Web UI**: [https://tenelabs.github.io/docsify-sitemap](https://tenelabs.github.io/docsify-sitemap)