### PR TITLE
Added drawcsify to plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [docsify-image-slider](https://github.com/erectbranch/docsify-image-slider) - A docsify plugin to create a slider from images.
 - [docsify-dashboard](https://github.com/erectbranch/docsify-dashboard) - A docsify plugin to create a dashboard from a JSON file.
 - [docsify-xpost](https://github.com/kevinhuang001/docsify-xpost) - A docsify plugin for rendering content blocks that resemble X posts.
+- [drawcsify](https://github.com/fenriskiba/drawcsify) - A docsify plugin to embed Draw.io diagrams into your documentation.
 
 ## Themes
 


### PR DESCRIPTION
This is a plugin forked off of [docsify-drawio](https://github.com/KonghaYao/docsify-drawio) that can embed [Draw.io](https://app.diagrams.net/) diagrams into your documentation.

## Features
* Simplified setup process
* Compatibility with `docsify-themeable` styles
* Background added to the diagram
* Uses the official Draw.io viewer