### PR TITLE
Add JSON Model site

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [Branch Log](https://erectbranch.netlify.app/#/) - A personal blog that records research and study notes.
 - [Subhranil's Docs](https://subhranildas.github.io/Docs/) - A customizable technical documentation site for quick reference on several topics.
 - [Injee Docs](https://injee.codeberg.page/docs/#/) - Docs for Injee - - The no configuration instant Database for front end developers.
+- [JSON Model](https://json-model.org/) - Docs and benches for JSON Model, a compact and intuitive JSON syntax to describe JSON data structures.
 
 ## Community Resources
 


### PR DESCRIPTION
It is worth noting about this site that it:
- uses docsify 5;
- mixes additional js for displaying performance bench in a dynamic radar (clic on an artifact in the bench list);
- relies on some statically generated markdown pages (about, bench list, model examples).