### PR TITLE
Add docsify-sigma plugin to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ A curated list of awesome things related to [docsify](https://docsify.js.org)
 - [docsify-display-colors](https://github.com/win-tm/docsify-display-colors) - A Docsify Plugin to visually display small Color-Swatches next to Hexcodes, RGB- or HSL-Colors. [@win-tm](https://github.com/win-tm)
 - [docsify-infographic](https://github.com/bulexu/docsify-infographic) - A plugin to render @antv/infographic diagrams in docsify.
 - [docsify-pytutor](https://github.com/sherlockmen/docsify-pytutor) - A docsify plugin that can visualize code execution. ✨(一个可以实现代码执行可视化的docsify插件).[@sherlockmen](https://github.com/sherlockmen)
+- [docsify-sigma](https://github.com/julienbusset/docsify-sigma) - Visualize a graph in your Docsify project using [Sigma.js](https://www.sigmajs.org/) and [Graphology](https://graphology.github.io/).
 
 ## Themes
 


### PR DESCRIPTION
Add docsify-sigma plugin to plugin list.

Plugin tested with the provided test kit on:
- Firefox (Linux Mint) and Brave (Android) by me,
- Google Chrome, Mac Safari, Firefox and Edge by @paulhibbitts ,
- Safari (iPhone17) by @trusktr .
